### PR TITLE
Fix Quickdraw Hiddenmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang
 EXPOSE 8686
 ADD . .
-RUN echo "---\nport: 8686\ndataDir: \"./data\"\nprojectPath: \".\"\n..."  >> config.yml
 RUN go get gopkg.in/yaml.v2
 RUN go build -i -o bin/sat ./server/go
-CMD ./bin/sat --config ./config.yml
+CMD ./bin/sat --config ./app/config/default_config.yml

--- a/app/src/js/image.js
+++ b/app/src/js/image.js
@@ -37,6 +37,13 @@ HiddenMap.prototype.appendList = function(shapes) {
   }
 };
 
+/**
+ * remove duplicate items in hidden map
+ */
+HiddenMap.prototype.removeDuplicate = function() {
+  this.list = Array.from(new Set(this.list));
+};
+
 HiddenMap.prototype.get = function(index) {
   if (index >= 0 && index < this.list.length) {
     return this.list[index];

--- a/app/src/js/seg2d.js
+++ b/app/src/js/seg2d.js
@@ -186,6 +186,8 @@ Seg2d.prototype.setState = function(state) {
       }
     }
     this.satItem.pushToHiddenMap(shapes);
+    // draw once for each shape
+    this.satItem._hiddenMap.removeDuplicate();
     this.satItem.redrawHiddenCanvas();
   }
 };


### PR DESCRIPTION
#5: Quickdraw encounters a problem when drawing along multiple polygons. Remove duplicate shapes from hidden map resolves the issue.
This branch also contains a minor change to Dockerfile to remove hardcoded config.yml.