### PR TITLE
Update sat.go

### DIFF
--- a/server/go/sat.go
+++ b/server/go/sat.go
@@ -712,7 +712,7 @@ func formValidation(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 
-	if r.FormValue("task_size") == "" {
+	if r.FormValue("item_type") != "video" && r.FormValue("task_size") == "" {
 		w.Write([]byte("Please specify a task size."))
 		return false
 	}


### PR DESCRIPTION
### BUG
Fail to create video annotation project.
### Steps
- in create project page, when item_type equals to 'select an option'
- make sure task_size field is empty
- change item_type to video. Now task_size field disappears since we don't need it.
- finish other fields
- click enter
### Error message
- Please specify a task size.

But for video annotation, we don't need task_size. 
In server side when check task_size, we should ignore such condition.
