### PR TITLE
UX feature: navigation from annotation panel to dashboard

### DIFF
--- a/app/src/annotation/image.html
+++ b/app/src/annotation/image.html
@@ -115,7 +115,7 @@
 <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow pull-left">
     <p>
       <div id="page-title" style="position: absolute; float:left; left: 30px;">
-        {{ .Task.ProjectOptions.PageTitle }}
+        <a id="project-title">{{ .Task.ProjectOptions.PageTitle }}</a>
         <!--<small class="navbar-small">ver 1.0.1</small>-->
         <a style="left: 10px" href="http://data-bdd.berkeley.edu/label/bbox/instruction.html" target="view_window" id="instruction_btn" class="btn btn-raised btn-info btn-regular">Instruction</a>
         <span class="navbar-small" style="padding-left: 20px">Labels </span>
@@ -235,12 +235,12 @@
 
 
 <script type="text/javascript">
-let labelType = {{ .Task.ProjectOptions.LabelType }};
-let itemType = {{ .Task.ProjectOptions.ItemType }};
+  let labelType = {{ .Task.ProjectOptions.LabelType }};
+  let itemType = {{ .Task.ProjectOptions.ItemType }};
+  let projectName = {{ .Task.ProjectOptions.Name }};
 </script>
 <script src="./js/image.js"></script>
-
-<script></script>
+<script src="./js/navigation.js"></script>
 
 </body>
 

--- a/app/src/annotation/point_cloud.html
+++ b/app/src/annotation/point_cloud.html
@@ -66,7 +66,7 @@
 <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow pull-left">
     <p>
     <div id="page-title" style="position: absolute; float:left; left: 30px;">
-        {{ .Task.ProjectOptions.PageTitle }}
+        <a id="project-title">{{ .Task.ProjectOptions.PageTitle }}</a>
         <!--<small class="navbar-small">ver 1.0.1</small>-->
         <a style="left: 10px" href="http://data-bdd.berkeley.edu/label/bbox/instruction.html" target="view_window" id="instruction_btn" class="btn btn-raised btn-info btn-regular">Instruction</a>
     </div>
@@ -177,8 +177,10 @@
 <script type="text/javascript">
   let labelType = {{ .Task.ProjectOptions.LabelType }};
   let itemType = {{ .Task.ProjectOptions.ItemType }};
+  let projectName = {{ .Task.ProjectOptions.Name }};
 </script>
 <script src="./js/point_cloud.js"></script>
+<script src="./js/navigation.js"></script>
 
 </body>
 

--- a/app/src/js/navigation.js
+++ b/app/src/js/navigation.js
@@ -1,0 +1,20 @@
+var projectTitle = document.getElementById('project-title');
+projectTitle.onclick = function goBack(){
+    // Find browser history offset
+    var history_offset = 0
+    if (document.referrer) {
+        // firefox, chrome, etc..
+        // new tab panels are present in the history.
+        history_offset = 2;
+    } else {
+        // under IE
+        history_offset = 1;
+    }
+
+    // If empty history or referrer is not from the same domain
+    if(history.length <= history_offset || document.referrer.indexOf(window.location.host) === -1){
+        window.location = './vendor?project_name=' + projectName;
+    } else {
+        history.back();
+    }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ let config = {
     create: __dirname + '/app/src/js/create.js',
     image: __dirname + '/app/src/js/image.index.js',
     point_cloud: __dirname + '/app/src/js/point_cloud/point_cloud.index.js',
+    navigation: __dirname + '/app/src/js/navigation.js',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
This PR smooths the navigation inside the application. On the annotation panel the project title is now clickable. This moves the user back in the history (could be admin project dashboard or vendor project dashboard) or loads the vendor project dashboard if the navigation history is not relevant.
