### PR TITLE
Adding a ParseMultipartForm line for force ValidateForm to wait until…

### DIFF
--- a/server/http/sat.go
+++ b/server/http/sat.go
@@ -19,6 +19,10 @@ import (
 	"strings"
 )
 
+const (
+	MAX_FORM_PARSE_MEM = 100*1024*1024 // Hold 100 mB of parsed multiform in mem before migrating to disk
+)
+
 //implements Serializable
 type Project struct {
 	Items    map[string][]Item `json:"items" yaml"items"`
@@ -858,6 +862,11 @@ func CreateTasks(project Project) {
 
 // server side create form validation
 func formValidation(w http.ResponseWriter, r *http.Request) error {
+	err := r.ParseMultipartForm(MAX_FORM_PARSE_MEM)
+	if err != nil {
+		w.Write([]byte("Body not in readable form format"))
+		return err
+	}
 	if r.FormValue("project_name") == "" {
 		w.Write([]byte("Please create a project name."))
 		return errors.New("invalid form: no project name")


### PR DESCRIPTION
I was running into issues where, if my form was too large, the project_name field was not being filled before validation was kicking in.

By forcing the ParseMultipartForm, the server was waiting until everything was ready before validating.

This mostly started to happen when I had large, fined-grained segmentation labels. Segmentation projects without pre-labels had no issue.

Adding the changes in this commit solved this problem for me. However, I am not sure if 100mB is a reasonable memory size for this project, but this is the number I used to solve my problem.