### PR TITLE
Fix category return

### DIFF
--- a/app/src/js/components/toolbar_category.tsx
+++ b/app/src/js/components/toolbar_category.tsx
@@ -79,7 +79,7 @@ class MultipleSelect extends React.Component<Props> {
         if (!categories) {
             return (<div> </div>);
         } else {
-            this.renderCategory(categories, classes);
+            return this.renderCategory(categories, classes);
         }
     }
 }


### PR DESCRIPTION
V2 failed to work because renderCategory is not returned when `category` is chosen. Now this works well.

- [x] Fixed category return